### PR TITLE
README: fix typo

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ init:
   # auto-yes for conda
   - cmd: conda config --set always_yes yes
   # update conda
-  - cmd: conda update -n base -c defaults conda
+  - cmd: conda update -n base -c conda-forge conda
 
 clone_folder: $(MAGICS_PYTHON_SRC)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   # auto-yes for conda
   - conda config --set always_yes yes
   # update conda
-  - conda update -n base -c defaults conda
+  - conda update -n base -c conda-forge conda
 
 install:
   # get magics-cxx for the test/python test scripts

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 .. |Travis Build| image:: https://img.shields.io/travis/ecmwf/magics-python/master.svg?logo=travis 
-   :target: https://travis-ci.org/ecmwf/magics/branches
+   :target: https://travis-ci.org/ecmwf/magics-python/branches
 .. |Appveyor Build| image:: https://img.shields.io/appveyor/ci/ecmwf/magics-python/master.svg?logo=appveyor
    :target: https://ci.appveyor.com/project/ecmwf/magics-python/branch/master


### PR DESCRIPTION
The travis build badge was linking to the magics build instead of
magics-python.