### PR TITLE
Tests: Add missing dependency and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@ magics/__pycache__
 build
 dist
 *.sublime-workspace
+.idea/
 # Ignore local virtual environment
 venv/
+.venv/
 
 # Ignore static typing
 .pytype

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,10 +40,10 @@ and "help wanted" is open to whoever wants to implement it.
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `magics-python` for local development. Please note this documentation assumes
+Ready to contribute? Here's how to set up ``magics-python`` for local development. Please note this documentation assumes
 you already have `virtualenv` and `Git` installed and ready to go.
 
-1. Fork the `magics-python` repo on GitHub.
+1. Fork the ``magics-python`` repo on GitHub.
 2. Clone your fork locally::
 
     $ cd path_for_the_repo
@@ -58,10 +58,10 @@ you already have `virtualenv` and `Git` installed and ready to go.
     This should change the shell to look something like
     (magics-python-env) $
 
-4. Install system dependencies as described in the README.rst file then install a known-good set of python dependencies and the your local copy with::
+4. Install program and dependencies as described in the README.rst file then install a known-good set of Python dependencies and the your local copy with::
 
-    $ pip install -r ci/requirements-tests.txt
-    $ pip install -e .
+    $ pip install --editable=.
+    $ pip install -r tests/requirements.txt
 
 5. Create a branch for local development::
 
@@ -69,10 +69,15 @@ you already have `virtualenv` and `Git` installed and ready to go.
 
    Now you can make your changes locally.
 
-6. The next step would be to run the test cases. `magics-python` uses py.test, you can run PyTest. Before you run pytest you should ensure all dependancies are installed::
+6. The next step would be to run the test cases. ``magics-python`` uses py.test, you can run PyTest::
 
-    $ pip install -r ci/requirements-dev.txt
-    $ pytest -v --flakes
+    # First, install some fixtures the test suite needs to run.
+    $ git clone --depth 1 https://github.com/ecmwf/magics-test.git
+    $ export MAGICS_PYTHON_TESTS=magics-test/test/gallery
+
+    # Invoke test suite.
+    export MAGPLUS_HOME=/usr/local/opt/magics-4.9.3
+    $ pytest -vvv --flakes
 
 7. Before raising a pull request you should also run tox. This will run the tests across different versions of Python::
 

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,10 @@ You may run a simple selfcheck command to ensure that your system is set up corr
     Found: Magics '4.0.0'.
     Your system is ready.
 
+If it does not work out of the box, try setting up the path to your MagPlus installation beforehand::
+
+    $ export MAGPLUS_HOME=/usr/local/opt/magics-4.9.3
+
 
 Usage
 -----
@@ -54,8 +58,6 @@ a 2m temperature grib file::
 
 
 You may try out the high level API in a python interpreter::
-
-
 
    from Magics import macro as magics
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-flakes
 xarray
 scipy
 cftime


### PR DESCRIPTION
Dear maintainers of `magics-python`,

first things first: Thanks a stack for your work on this software.

While trying to investigate a problem with `Magics.version` on macOS, we discovered some gaps in the documentation how to run the test suite. After figuring it out, we wanted to share it back on behalf of improvements to the documentation.

So, this patch fills in some gaps to educate people how to exactly run the full test suite. Along the lines, it adds the missing `pytest-flakes` package.

Within the README, it adds a note about setting the `MAGPLUS_HOME` environment variable, which is helpful in non-standard setup location environments.

With kind regards,
Andreas.
